### PR TITLE
preserve original value of portable dirs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -715,14 +715,39 @@ fn try_set_portable(kind: &str, dir: &PathBuf) {
     if dir.is_dir() {
         match kind {
             "home" => {
+                if get_env_var("REAL_HOME").is_empty() {
+                    if let Ok(real_homedir) = env::var("HOME") {
+                        env::set_var("REAL_HOME", real_homedir);
+                    }
+                }
                 eprintln!("Setting $HOME to {:?}", dir);
                 env::set_var("HOME", dir)
             }
             "config" => {
+                if get_env_var("REAL_XDG_CONFIG_HOME").is_empty() {
+                    if let Ok(real_configdir) = env::var("XDG_CONFIG_HOME") {
+                        env::set_var("REAL_XDG_CONFIG_HOME", real_configdir);
+                    } else {
+                        if let Ok(home) = env::var("HOME") {
+                            let default_configdir = PathBuf::from(home).join(".config");
+                            env::set_var("REAL_XDG_CONFIG_HOME", default_configdir);
+                        }
+                    }
+                }
                 eprintln!("Setting $XDG_CONFIG_HOME to {:?}", dir);
                 env::set_var("XDG_CONFIG_HOME", dir)
             }
             "share" => {
+                if get_env_var("REAL_XDG_DATA_HOME").is_empty() {
+                    if let Ok(real_sharedir) = env::var("XDG_DATA_HOME") {
+                        env::set_var("REAL_XDG_DATA_HOME", real_sharedir);
+                    } else {
+                        if let Ok(home) = env::var("HOME") {
+                            let default_sharedir = PathBuf::from(home).join(".local").join("share");
+                            env::set_var("REAL_XDG_DATA_HOME", default_sharedir);
+                        }
+                    }
+                }
                 eprintln!("Setting $XDG_DATA_HOME to {:?}", dir);
                 env::set_var("XDG_DATA_HOME", dir)
             }


### PR DESCRIPTION
This condition happens when the value of `HOME`, `XDG_{CONFIG,DATA}_HOME` is about to be changed by the uruntime to the portable dir. 

It checks if `REAL_HOME` is not set, if so then it sets `HOME` to `REAL_HOME` before changing the value to the portable home.

This allows the value to be preserved to be later restored by a library that would check this. 

This helps fixing this issue: https://github.com/pkgforge-dev/Anylinux-AppImages/issues/12

Which I'm also trying to fix in a very hacky way by restoring to the parent env here: https://github.com/pkgforge-dev/Anylinux-AppImages/pull/48

However that solution has its limitations, like for example if `XDG_CONFIG_HOME` is set by nested portable appimages, the value would be restored to the previous appimage and not the real value, this is why a variable that stores the real value is needed.

---

Tested it working: 

<img width="781" height="314" alt="image" src="https://github.com/user-attachments/assets/bc56fbfa-738a-4db4-8658-4399a33dfd2a" />

<img width="644" height="214" alt="image" src="https://github.com/user-attachments/assets/03bb47d8-fcef-4739-acfe-0b0d1b77767a" />

